### PR TITLE
Fixed install path for config dir

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,7 +31,7 @@ install(DIRECTORY launch
   DESTINATION share/${PROJECT_NAME}
 )
 install(DIRECTORY config
-  DESTINATION share/${PROJECT_NAME}/config/
+  DESTINATION share/${PROJECT_NAME}
 )
 install(DIRECTORY data
   DESTINATION share/${PROJECT_NAME}


### PR DESCRIPTION
Fixes `[WARNING] [launch_ros.actions.node]: Parameter file path is not a file` while launching `ros2 launch doom_ros doom_ros.launch.py`.

